### PR TITLE
Feat : User 도메인 설계하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-crypto:6.4.4' //비밀번호 암호화만 가져다쓸것
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.mysql:mysql-connector-j:8.0.32'
@@ -37,6 +38,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hikers/hikemate/config/JacksonConfig.java
+++ b/src/main/java/com/hikers/hikemate/config/JacksonConfig.java
@@ -1,0 +1,16 @@
+package com.hikers.hikemate.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);  // SNAKE_CASE 적용
+    }
+}

--- a/src/main/java/com/hikers/hikemate/config/SecurityConfig.java
+++ b/src/main/java/com/hikers/hikemate/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.hikers.hikemate.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/hikers/hikemate/controller/UserController.java
+++ b/src/main/java/com/hikers/hikemate/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.hikers.hikemate.controller;
+
+
+import com.hikers.hikemate.dto.UserSignupDTO;
+import com.hikers.hikemate.entity.User;
+import com.hikers.hikemate.jwt.JwtUtil;
+import com.hikers.hikemate.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody UserSignupDTO signupDTO) {
+        User savedUser = userService.registerUser(signupDTO);
+
+        // 응답 데이터 포맷 간단히 구성
+        return ResponseEntity.ok().body(
+                new SignupResponse(savedUser.getUserId(), savedUser.getNickname(), savedUser.getEmail())
+        );
+    }
+
+    // 응답 DTO (필요한 필드만 보내기)
+    private record SignupResponse(String user_id, String nickname, String email) {}
+}

--- a/src/main/java/com/hikers/hikemate/controller/UserController.java
+++ b/src/main/java/com/hikers/hikemate/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.hikers.hikemate.controller;
 
 
+import com.hikers.hikemate.dto.LoginRequestDTO;
+import com.hikers.hikemate.dto.LoginResponseDTO;
 import com.hikers.hikemate.dto.UserSignupDTO;
 import com.hikers.hikemate.entity.User;
 import com.hikers.hikemate.jwt.JwtUtil;
@@ -8,9 +10,15 @@ import com.hikers.hikemate.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import com.hikers.hikemate.jwt.JwtUtil;
+
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
 
     // 회원가입
@@ -33,4 +42,53 @@ public class UserController {
 
     // 응답 DTO (필요한 필드만 보내기)
     private record SignupResponse(String user_id, String nickname, String email) {}
+    // 로그인
+
+    @PostMapping("/login")
+    public ResponseEntity<?> loginUser(@RequestBody LoginRequestDTO loginRequestDTO) {
+
+        String token = userService.login(loginRequestDTO);
+
+        // JWT 토큰 반환
+        return ResponseEntity.ok().body(new LoginResponseDTO(token));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Map<String, Object>> logout() {
+        // 응답 객체에 로그아웃 성공 메시지와 사인 추가
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "200 OK");  // 사인
+        response.put("message", "로그아웃 성공. JWT 토큰을 삭제가 필요합니당.");
+
+        // OK 응답과 함께 응답 객체 반환
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+
+    @DeleteMapping("/user")
+    public ResponseEntity<?> deleteUser(@RequestHeader("Authorization") String token) {
+        String jwt = token.replace("Bearer ", "");
+
+        if (!JwtUtil.validateToken(jwt)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+
+        String userId = JwtUtil.extractUserId(jwt);  // 여기서 "test123" 같은 문자열 userId가 나옴
+
+        boolean isDeleted = userService.deleteUserByUserId(userId);
+
+        if (isDeleted) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "200 OK");
+            response.put("message", "회원 탈퇴 성공");
+            return ResponseEntity.ok(response);
+        } else {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "400 BAD REQUEST");
+            response.put("message", "회원 탈퇴 실패");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
+
+    }
+
 }

--- a/src/main/java/com/hikers/hikemate/dto/LoginRequestDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/LoginRequestDTO.java
@@ -1,0 +1,13 @@
+package com.hikers.hikemate.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequestDTO {
+    private String userId;
+    @JsonProperty("passwd")
+    private String password;
+}

--- a/src/main/java/com/hikers/hikemate/dto/LoginResponseDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/LoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.hikers.hikemate.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginResponseDTO {
+    private String token;
+
+    public LoginResponseDTO(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/hikers/hikemate/dto/SignupResponseDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/SignupResponseDTO.java
@@ -1,9 +1,12 @@
 package com.hikers.hikemate.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
-public class UserResponseDTO {
+@Getter
+@AllArgsConstructor
+public class SignupResponseDTO {
     private String user_id;
     private String nickname;
     private String email;

--- a/src/main/java/com/hikers/hikemate/dto/UserResponseDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/UserResponseDTO.java
@@ -1,0 +1,10 @@
+package com.hikers.hikemate.dto;
+
+import lombok.Data;
+
+@Data
+public class UserResponseDTO {
+    private String user_id;
+    private String nickname;
+    private String email;
+}

--- a/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
@@ -1,0 +1,13 @@
+package com.hikers.hikemate.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSignupDTO {
+    private String user_id;
+    private String password;
+    private String email;
+    private String phone;
+}

--- a/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
 public class UserSignupDTO {
     private String user_id;
     private String password;

--- a/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
+++ b/src/main/java/com/hikers/hikemate/dto/UserSignupDTO.java
@@ -1,12 +1,30 @@
 package com.hikers.hikemate.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class UserSignupDTO {
-    private String user_id;
+
+    @NotBlank
+    @JsonProperty("user_id")  // 프론트의 user_id -> 백엔드의 userId로 매핑
+    private String userId;
+
+    @NotBlank
+    @JsonProperty("passwd")
     private String password;
+
+    @NotBlank
+    private String nickname;
+
+    @Email
     private String email;
-    private String phone;
+
+
 }

--- a/src/main/java/com/hikers/hikemate/entity/User.java
+++ b/src/main/java/com/hikers/hikemate/entity/User.java
@@ -1,0 +1,44 @@
+package com.hikers.hikemate.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter // 자동으로 모든 필드 getter setter 메서드 자동 생성
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String user_id; //사용자 아이디
+
+    @NotBlank
+    private String passwd; // 사용자 비밀번호
+
+    @NotBlank
+    private String nickname; // 사용자 닉네임
+
+    @Email
+    @NotBlank
+    private String Email; //사용자 이메일
+
+    public User (){}
+
+    //생성자
+    public User(String user_id, String passwd, String nickname, String Email) {
+        this.user_id = user_id;
+        this.passwd = passwd;
+        this.nickname = nickname;
+        this.Email = Email;
+    }
+
+}

--- a/src/main/java/com/hikers/hikemate/entity/User.java
+++ b/src/main/java/com/hikers/hikemate/entity/User.java
@@ -1,44 +1,35 @@
 package com.hikers.hikemate.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter // 자동으로 모든 필드 getter setter 메서드 자동 생성
 @Entity
+@Builder
+@Table(name = "user")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank
-    private String user_id; //사용자 아이디
+    @Column(name = "user_id", unique = true, nullable = false)
+    private String userId;
 
-    @NotBlank
-    private String passwd; // 사용자 비밀번호
+    @NotEmpty(message = "Password 는 빈칸일 수 없음")
+    private String passwd;
 
-    @NotBlank
-    private String nickname; // 사용자 닉네임
+    @NotEmpty(message = "Nickname 은 빈칸일 수 없음")
+    private String nickname;
 
     @Email
-    @NotBlank
-    private String Email; //사용자 이메일
+    @NotEmpty(message = "Email 은 빈칸일 수 없음")
+    private String email;
 
-    public User (){}
-
-    //생성자
-    public User(String user_id, String passwd, String nickname, String Email) {
-        this.user_id = user_id;
-        this.passwd = passwd;
-        this.nickname = nickname;
-        this.Email = Email;
-    }
 
 }

--- a/src/main/java/com/hikers/hikemate/jwt/JwtUtil.java
+++ b/src/main/java/com/hikers/hikemate/jwt/JwtUtil.java
@@ -1,0 +1,28 @@
+package com.hikers.hikemate.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import java.util.Date;
+
+public class JwtUtil {
+    private static final String SECRET_KEY = "yourSecretKey"; //비밀키
+
+    public static String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간 유효
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    public static boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/hikers/hikemate/jwt/JwtUtil.java
+++ b/src/main/java/com/hikers/hikemate/jwt/JwtUtil.java
@@ -1,18 +1,21 @@
 package com.hikers.hikemate.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
+@Component
 public class JwtUtil {
-    private static final String SECRET_KEY = "yourSecretKey"; //비밀키
+    private static final String SECRET_KEY = "yourVeryLongSuperSecretKeyThatIsAtLeast32Charsssss"; //비밀키
 
     public static String generateToken(String username) {
         return Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // 1시간 유효
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60* 12)) // 12시간 유효
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();
     }
@@ -24,5 +27,12 @@ public class JwtUtil {
         } catch (Exception e) {
             return false;
         }
+    }
+    public static String extractUserId(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(SECRET_KEY)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
     }
 }

--- a/src/main/java/com/hikers/hikemate/repository/UserRepository.java
+++ b/src/main/java/com/hikers/hikemate/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.hikers.hikemate.repository;
+
+import com.hikers.hikemate.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    //아이디 또는 이메일로 사용자 찾기 ( 이메일도 포함인가?)
+    Optional<User> findByUsername(String user_id);
+
+    Optional<User> fingByEmail(String email);
+}

--- a/src/main/java/com/hikers/hikemate/repository/UserRepository.java
+++ b/src/main/java/com/hikers/hikemate/repository/UserRepository.java
@@ -11,4 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String user_id);
 
     Optional<User> fingByEmail(String email);
+
+    boolean existsByUserId(String user_id);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hikers/hikemate/repository/UserRepository.java
+++ b/src/main/java/com/hikers/hikemate/repository/UserRepository.java
@@ -7,11 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    //아이디 또는 이메일로 사용자 찾기 ( 이메일도 포함인가?)
-    Optional<User> findByUsername(String user_id);
-
-    Optional<User> fingByEmail(String email);
-
-    boolean existsByUserId(String user_id);
-    boolean existsByEmail(String email);
+    //아이디 또는 이메일로 사용자 찾기
+    Optional<User> findByUserId(String user_id);
 }

--- a/src/main/java/com/hikers/hikemate/service/UserService.java
+++ b/src/main/java/com/hikers/hikemate/service/UserService.java
@@ -1,15 +1,50 @@
 package com.hikers.hikemate.service;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import com.hikers.hikemate.dto.UserSignupDTO;
+import com.hikers.hikemate.entity.User;
 import com.hikers.hikemate.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
+@Service
+@RequiredArgsConstructor
 public class UserService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private BCryptPasswordEncoder bCryptPasswordEncoder;
+    @Transactional
+    public User registerUser(UserSignupDTO request) {
+        // 1. 중복 검사
+        if (userRepository.findByUserId(request.getUserId()).isPresent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 사용 중인 아이디입니다.");
+
+        }
+
+        // 2. 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        // 3. 엔티티 생성 및 저장
+        User user = User.builder()
+                .userId(request.getUserId())
+                .passwd(encodedPassword)
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .build();
+
+        return userRepository.save(user);
+    }
+
+    public User findUserByUserId(String userId) {
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다: " + userId));
+    }
+
 }

--- a/src/main/java/com/hikers/hikemate/service/UserService.java
+++ b/src/main/java/com/hikers/hikemate/service/UserService.java
@@ -1,0 +1,15 @@
+package com.hikers.hikemate.service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.hikers.hikemate.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+}

--- a/src/main/java/com/hikers/hikemate/service/UserService.java
+++ b/src/main/java/com/hikers/hikemate/service/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
     public User registerUser(UserSignupDTO request) {
         // 1. 중복 검사
         if (userRepository.findByUserId(request.getUserId()).isPresent()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 사용 중인 아이디입니다.");
+            return null;
 
         }
 
@@ -49,10 +49,15 @@ public class UserService {
     // 로그인 처리
     public String login(LoginRequestDTO loginRequestDTO) {
         User user = userRepository.findByUserId(loginRequestDTO.getUserId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "아이디가 존재하지 않습니다."));
+                .orElse(null);
 
+        if (user == null) {
+            return "ID_NOT_FOUND";  // 아이디가 없을 경우
+        }
+
+        // 비밀번호 확인
         if (!passwordEncoder.matches(loginRequestDTO.getPassword(), user.getPasswd())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+            return "INVALID_PASSWORD";  // 비밀번호 불일치
         }
 
         return JwtUtil.generateToken(user.getUserId());

--- a/src/main/java/com/hikers/hikemate/service/UserService.java
+++ b/src/main/java/com/hikers/hikemate/service/UserService.java
@@ -1,7 +1,9 @@
 package com.hikers.hikemate.service;
 
+import com.hikers.hikemate.dto.LoginRequestDTO;
 import com.hikers.hikemate.dto.UserSignupDTO;
 import com.hikers.hikemate.entity.User;
+import com.hikers.hikemate.jwt.JwtUtil;
 import com.hikers.hikemate.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -42,9 +46,30 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    // 로그인 처리
+    public String login(LoginRequestDTO loginRequestDTO) {
+        User user = userRepository.findByUserId(loginRequestDTO.getUserId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "아이디가 존재하지 않습니다."));
+
+        if (!passwordEncoder.matches(loginRequestDTO.getPassword(), user.getPasswd())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+        }
+
+        return JwtUtil.generateToken(user.getUserId());
+    }
+
+
     public User findUserByUserId(String userId) {
         return userRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다: " + userId));
     }
+    public boolean deleteUserByUserId(String userId) {
+        Optional<User> userOptional = userRepository.findByUserId(userId);
 
+        if (userOptional.isPresent()) {
+            userRepository.delete(userOptional.get());
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
  closed #3 


## ✨ 작성한 방식

1. jwt token 방식 사용하였음 
(단, 이때, refresh token이나 blacklist를 사용하지는 않았습니다.)
➡️ 추후 사용자 인증 관련 작업들을 위해서 securityfilter와 같은 기능이 필요할 것으로 보입니다.

2. 현재 에러와 관련한 response 형태는 
{"message" : " ", "status": " " } 로 일괄 통합한 상태입니다.

‼️기능 개발 중  예상치 못했던 에러사항 ‼️
### problem
JPA 에서 엔티티 필드명과 데이터베이스 컬럼며이 매칭될 때 문제가 발생

### description
findByUserId 같은 메서드를 사용하기 위해서서는  JPA 에서 제공하는 쿼리 메서드 이름 규칙을 따라야함. 이때, JPA는 기본적으로 필드명을 CamelCase로 다룸... 
따라서, 언더바 형식의 필드명을 인식하지 못함.
=> user_id... 로 정해놓은 필드명 어떠카죠..?

### solution

erd 설계 바꾸자. api 설계에서 쿼리명들 바꿀까? 안돼 프론트에게 민폐..

<application_properties에 해당 항목 추가>
spring.jackson.property-naming-strategy=SNAKE_CASE

언더바 형식으로 클라이언트에서 넘어와도 userId로 인식하도록 함 + 해당 DTO에서 @JsonProperty("user_id") 라 사용해서 우리의 userId랑 연결되도록 설정해놓음. 이러면 JPA 메서드 사용 가능함.





